### PR TITLE
避免 issue template 中 checkbox 之间的额外纵向间距

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.yaml
@@ -12,16 +12,16 @@ body:
     attributes:
       label: 先决条件
       options:
-        - label: |
+        - label: |-
             我已尝试更新[模板版本](https://github.com/nju-lug/NJUThesis/blob/master/CHANGELOG.md)
           required: true
-        - label: |
+        - label: |-
             我已检索[模板手册](http://mirrors.ctan.org/macros/unicodetex/latex/njuthesis/njuthesis.pdf)
           required: true
-        - label: |
+        - label: |-
             我已检索[项目 wiki](https://github.com/nju-lug/NJUThesis/wiki)
           required: true
-        - label: |
+        - label: |-
             我已确认这个问题没有在[其他 issues](https://github.com/nju-lug/NJUThesis/issues) 中提出过。
           required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/2-feat_request.yaml
+++ b/.github/ISSUE_TEMPLATE/2-feat_request.yaml
@@ -8,16 +8,16 @@ body:
     attributes:
       label: 先决条件
       options:
-        - label: |
+        - label: |-
             我已尝试更新模板版本
           required: true
-        - label: |
+        - label: |-
             我已检索[模板手册](http://mirrors.ctan.org/macros/unicodetex/latex/njuthesis/njuthesis.pdf)
           required: true
-        - label: |
+        - label: |-
             我已检索[项目 wiki](https://github.com/nju-lug/NJUThesis/wiki)
           required: true
-        - label: |
+        - label: |-
             我已确认这个请求没有在[其他 issues](https://github.com/tuna/issues/issues)中提出过。
           required: true
   - type: textarea


### PR DESCRIPTION
修改前，issue 模板开头的四个 checkbox 之间有较大纵向间距，例子见 #240
![image](https://github.com/nju-lug/NJUThesis/assets/6376638/50faa77d-9fc4-415d-a55a-48b894348757)

修改后，四个 checkbox 之间的间距恢复正常，见测试 https://github.com/muzimuzhi/NJUThesis/issues/1 和 https://github.com/muzimuzhi/NJUThesis/issues/2 。

![image](https://github.com/nju-lug/NJUThesis/assets/6376638/71e08c1d-d802-4e3a-817a-0e556f0b2761)

修改后的间距也和手动输入
```
- [x] Item A
- [x] Item B
- [x] Item C
```
得到的一致。
- [x] Item A
- [x] Item B
- [x] Item C

------

见 YAML Spec v1.2.2, sec. 8.1.1.2. Block Chomping Indicator
https://yaml.org/spec/1.2.2/#8112-block-chomping-indicator

