### PR TITLE
Fix: 修复表格标题位置问题

### DIFF
--- a/source/njuthesis.dtx
+++ b/source/njuthesis.dtx
@@ -4340,6 +4340,7 @@ To produce the documentation run the original source files ending with
     booktabs,
     caption,
     graphicx,
+    floatrow
   }
 \@@_loadpkg_nthm:
 %    \end{macrocode}
@@ -6108,6 +6109,7 @@ To produce the documentation run the original source files ending with
   }
 \captionsetup [ figure ] { style = njucap }
 \captionsetup [ table  ] { style = njucap }
+\floatsetup[table]{ capposition=top, captionskip=0pt }
 %    \end{macrocode}
 %
 % \begin{macro}{\ctex_patch_cmd:Nnn}


### PR DESCRIPTION
2024年本科生毕业论文模板中增加了如下的表格内容要求：
![image](https://github.com/nju-lug/NJUThesis/assets/52662784/e2d7a7d4-fea1-4289-a5be-c6e3ee362aaa)

虽然可以通过修改caption位置来使得表格标题在上方，但tex.nju里默认的table模板当中caption还是靠下的，因此我尝试将这一内容放在模板中定义来防止手滑没改位置的情况出现。

我尝试了一些类似于`\captionsetup[table]{position=top}`的方式，但是似乎放在各处都不起作用。最后还是把我能找到的唯一能用的方法，也就是使用floatrow，给引进来了（虽然看了一眼changelog发现它在2021年被移除过）

如果有更好的修改方式还请指正！