### PR TITLE
修复 cleveref 的兼容问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ## [未发布]
 
+### 修复
+
+- 修复 macoffice 选项下无法自动加载华文中宋问题 - [#269]
+  - 感谢 [@liudongmiao]！
+- 提供新版 LaTeX2e 下兼容 cleveref 的补丁 - [#263]
+
 ## [1.4.2] - 2024-11-08
 
 ### 新增
@@ -683,6 +689,8 @@
 [#248]: https://github.com/nju-lug/NJUThesis/issues/248
 [#251]: https://github.com/nju-lug/NJUThesis/discussions/251
 [#253]: https://github.com/nju-lug/NJUThesis/pull/253
+[#263]: https://github.com/nju-lug/NJUThesis/issues/263
+[#269]: https://github.com/nju-lug/NJUThesis/pull/269
 
 [CTeX-org/ctex-kit#678]: https://github.com/CTeX-org/ctex-kit/pull/678
 [CTeX-org/ctex-kit#700]: https://github.com/CTeX-org/ctex-kit/pull/700
@@ -702,3 +710,4 @@
 [@stone-zeng]: https://github.com/stone-zeng
 [@liudongmiao]: https://github.com/liudongmiao
 [@muzimuzhi]: https://github.com/muzimuzhi
+[@liudongmiao]: https://github.com/liudongmiao

--- a/README-CTAN.md
+++ b/README-CTAN.md
@@ -46,4 +46,4 @@ version.
 
 -----
 
-Copyright (C) 2021 - 2024 by NJU LUG.
+Copyright (C) 2021 - 2025 by NJU LUG.

--- a/source/njuthesis.dtx
+++ b/source/njuthesis.dtx
@@ -2,7 +2,7 @@
 % !TeX program  = XeLaTeX
 % !TeX encoding = UTF-8
 %
-% Copyright (C) 2021 - 2024
+% Copyright (C) 2021 - 2025
 % by Nanjing University Linux User Group
 % <git+nju-lug-email-3104-issue-@yaoge123.cn>
 %
@@ -49,7 +49,7 @@
 
 \preamble
 
-Copyright (C) 2021 - 2024
+Copyright (C) 2021 - 2025
 by Nanjing University Linux User Group
 <git+nju-lug-email-3104-issue-@yaoge123.cn>
 
@@ -4465,6 +4465,26 @@ To produce the documentation run the original source files ending with
         eufrak, mathrsfs, newtxmath, upgreek
       }
       { \@@_check_pkg_conflict:nn { unicode-math } {#1} }
+  }
+%    \end{macrocode}
+%
+% \changes{v1.4}{2025/02/24}{提供新版 \LaTeXe{} 下兼容 cleveref 的补丁。}
+% 新版 \LaTeXe{} 的补丁，详见 \url{https://github.com/CTeX-org/ctex-kit/issues/725}。
+%    \begin{macrocode}
+\bool_if:NT \g_@@_opt_load_cref_bool
+  {
+    \@ifl@t@r \fmtversion { 2024/11/01 }
+      {
+        \ctex_at_end_package:nn { cleveref }
+          {
+            \__ctex_cleveref_hook_aux:N \refstepcounter@noarg
+            \hook_gput_code:nnn { begindocument/end } { ctex }
+                {
+                  \cs_if_exist:NT \firstaid@cref@updatelabeldata
+                    { \__ctex_cleveref_hook_aux:N \firstaid@cref@updatelabeldata }
+                }
+          }
+      } { }
   }
 %    \end{macrocode}
 %


### PR DESCRIPTION
摘取 <https://github.com/muzimuzhi/ctex-kit/commit/5b786a4e1d1380b386703072e27ac1203500e78a> 修复 #263 提到的编译问题。