### PR TITLE
fix: undergraduate thesis: use 2026 version (院系=>学院)

### DIFF
--- a/source/njuthesis.dtx
+++ b/source/njuthesis.dtx
@@ -8717,7 +8717,7 @@ To produce the documentation run the original source files ending with
 % 这里加入伸缩量，是因为 \hologo{LuaLaTeX} 下全角冒号的宽度并不能被正确识别。
 %    \begin{macrocode}
     { colon         } { ：\hskip 0pt minus .4em } { : \c_space_tl },
-%<def-u|def-g>    { dept          } { 院系            } { DEPARTMENT            },
+%<def-u|def-g>    { dept          } { 学院            } { DEPARTMENT            },
     { figure        } { 图              } { figure                },
     { keywords      } { 关键词          } { KEYWORDS              },
     { lang          } { 中文            } { 英文                  },
@@ -8746,7 +8746,7 @@ To produce the documentation run the original source files ending with
   {
 %<*def-u>
     本人郑重承诺：所呈交的毕业论文（设计）（题目： \g_@@_info_title_tl ）
-    是在指导教师的指导下严格按照学校和院系有关规定由本人独立完成的。
+    是在指导教师的指导下严格按照学校和学院有关规定由本人独立完成的。
     本毕业论文（设计）中引用他人观点及参考资源的内容均已标注引用，
     如出现侵犯他人知识产权的行为，由本人承担相应法律责任。
     本人承诺不存在抄袭、伪造、篡改、代写、买卖毕业论文（设计）等违纪行为。


### PR DESCRIPTION
2026 年的本科毕业论文模板进行了更新，主要的改动是将院系改为了学院。

<img width="721" height="790" alt="image" src="https://github.com/user-attachments/assets/8b40056f-ae14-4fec-ac4e-d71c2ba7c04d" />
<img width="721" height="790" alt="image" src="https://github.com/user-attachments/assets/be0179df-0420-4692-b01b-7ef53567d23b" />
<img width="721" height="790" alt="image" src="https://github.com/user-attachments/assets/a1096838-b6ff-4acc-87ef-12f2903b532a" />
<img width="721" height="790" alt="image" src="https://github.com/user-attachments/assets/1140391c-3292-49b5-bfd4-70989e37058a" />
